### PR TITLE
feat: Light translation, rotation, and Pivot rotation controls (branch: feature/lights-rotation-translation should merge w. main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ minilibx-linux/
 *.o
 .vscode/
 .gdb_history
+rt

--- a/controller.c
+++ b/controller.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   controller.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: apuddu <apuddu@student.42roma.it>          +#+  +:+       +#+        */
+/*   By: amema <amema@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 15:41:27 by amema             #+#    #+#             */
-/*   Updated: 2025/03/09 20:30:04 by apuddu           ###   ########.fr       */
+/*   Updated: 2025/03/10 13:24:37 by amema            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,8 +94,63 @@ int	handle_mouse(int k, int x, int y, t_ctx *ctx)
 int	handle_key_down(int key, t_ctx *ctx)
 {
 	t_control	*ctrl;
-
 	ctrl = &ctx->control;
+
+	// if (key == 65307)
+	// 	mlx_loop_end(ctx->mlx);
+
+	if (key == 'm')
+	{
+		ctrl->light_mode = !ctrl->light_mode;
+		printf("Light mode: %s\n", ctrl->light_mode ? "ON" : "OFF");
+		reset_show(ctx);
+		return (0);
+	}
+	
+	if (ctrl->light_mode)
+    {
+        //@ least one light in the scene
+        if (ctx->scene->lights->size > 0)
+        {
+            t_light *light = ctx->scene->lights->arr[0];
+
+            // translaction w. WASD and SPACE
+            if (key == 'w')
+                translate_light(light, (t_vec3){0, 0,  0.3f});
+            else if (key == 's')
+                translate_light(light, (t_vec3){0, 0, -0.3f});
+            else if (key == 'a')
+                translate_light(light, (t_vec3){-0.3f, 0, 0});
+            else if (key == 'd')
+                translate_light(light, (t_vec3){ 0.3f, 0, 0});
+            else if (key == ' ')
+                translate_light(light, (t_vec3){0, 0.3f, 0});
+            // rotation w. i/k/j/l/u/o
+            else if (key == 'i' || key == 'k' || key == 'j' ||
+                     key == 'l' || key == 'u' || key == 'o')
+            {
+                t_frame rot;
+                float angle = 5.0f;
+                if (key == 'i')
+                    rot = rotx(angle);
+                else if (key == 'k')
+                    rot = rotx(-angle);
+                else if (key == 'j')
+                    rot = roty(angle);
+                else if (key == 'l')
+                    rot = roty(-angle);
+                else if (key == 'u')
+                    rot = rotz(angle);
+                else // 'o'
+                    rot = rotz(-angle);
+
+                rotate_light(light, rot);
+            }
+        }
+        reset_show(ctx);
+        return (0);
+    }
+	
 	if (key == 65293)
 	{
 		clear_selection(ctx);
@@ -178,10 +233,10 @@ int	handle_key_down(int key, t_ctx *ctx)
 			reset_show(ctx);
 		}
     }
-	    // Comandi di rotazione: I/K per rotazione attorno all'asse X,
-    // J/L per Y, U/O per Z.
-    
 	
+	// Comandi di rotazione: I/K per rotazione attorno all'asse X,
+    // J/L per Y, U/O per Z.
+
 	if (key == 'i' || key == 'k' || key == 'j' ||
         key == 'l' || key == 'u' || key == 'o')
     {
@@ -208,13 +263,14 @@ int	handle_key_down(int key, t_ctx *ctx)
             rotate_camera(&ctx->scene->camera, rot);
         reset_show(ctx);
     }
-
 	return (0);
 	
 }
 
 int	handle_key_up(int key, t_control *ctrl)
 {
+	if (ctrl->light_mode)
+		return (0);
 	printf("press key (%d)\n", key);
 	if (key == 65505 || key == 65506)
 	{

--- a/light_transform.c
+++ b/light_transform.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   light_transform.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: amema <amema@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/10 12:01:42 by amema             #+#    #+#             */
+/*   Updated: 2025/03/10 13:21:10 by amema            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "rt.h"
+
+void translate_light(t_light *light, t_vec3 delta)
+{
+    light->pos = add(light->pos, delta);
+}
+
+
+// approach1: rotate a light around the world origin (0, 0, 0)
+void rotate_light(t_light *light, t_frame rot)
+{
+    t_vec3 new_pos = v_to_world(light->pos, rot);
+    light->pos = new_pos;
+}
+
+// approach2: rotate a light around a pivot point
+// This fun rotates a light around a given pivot point using a specified rotation.
+// ex: light(5, 0, 0) && pivot @ (0, 0, 0) -> rot by 90 around z-ax -> result: will move light to (0, 5, 0).
+
+void rotate_light_pivot(t_light *light, t_frame rot, t_vec3 pivot)
+{
+    t_vec3 rel = sub(light->pos, pivot); // calc relative vector pivot -> light
+    rel = v_to_world(rel, rot); // rotare relative vector
+    light->pos = add(pivot, rel); // update light position by adding the pivot to the rotated vector
+}

--- a/light_transform.c
+++ b/light_transform.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   light_transform.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amema <amema@student.42.fr>                +#+  +:+       +#+        */
+/*   By: apuddu <apuddu@student.42roma.it>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/10 12:01:42 by amema             #+#    #+#             */
-/*   Updated: 2025/03/10 13:21:10 by amema            ###   ########.fr       */
+/*   Updated: 2025/03/10 17:07:24 by apuddu           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,14 @@
 
 void translate_light(t_light *light, t_vec3 delta)
 {
-    light->pos = add(light->pos, delta);
+	light->pos = add(light->pos, delta);
 }
-
 
 // approach1: rotate a light around the world origin (0, 0, 0)
 void rotate_light(t_light *light, t_frame rot)
 {
-    t_vec3 new_pos = v_to_world(light->pos, rot);
-    light->pos = new_pos;
+	t_vec3 new_pos = v_to_world(light->pos, rot);
+	light->pos = new_pos;
 }
 
 // approach2: rotate a light around a pivot point
@@ -31,7 +30,7 @@ void rotate_light(t_light *light, t_frame rot)
 
 void rotate_light_pivot(t_light *light, t_frame rot, t_vec3 pivot)
 {
-    t_vec3 rel = sub(light->pos, pivot); // calc relative vector pivot -> light
-    rel = v_to_world(rel, rot); // rotare relative vector
-    light->pos = add(pivot, rel); // update light position by adding the pivot to the rotated vector
+	t_vec3 rel = sub(light->pos, pivot); // calc relative vector pivot -> light
+	rel = v_to_world(rel, rot); // rotare relative vector
+	light->pos = add(pivot, rel);		 // update light position by adding the pivot to the rotated vector
 }

--- a/rt.h
+++ b/rt.h
@@ -6,22 +6,22 @@
 /*   By: apuddu <apuddu@student.42roma.it>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 14:35:28 by amema             #+#    #+#             */
-/*   Updated: 2025/03/10 17:21:13 by apuddu           ###   ########.fr       */
+/*   Updated: 2025/03/10 18:08:30 by apuddu           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef RT_H
 # define RT_H
 
-# include <fcntl.h>
 # include <get_next_line.h>
 # include <libft.h>
+# include <vector.h>
 # include <math.h>
-# include <mlx.h>
 # include <stdio.h>
 # include <stdlib.h>
+# include <mlx.h>
+# include <fcntl.h>
 # include <unistd.h>
-# include <vector.h>
 
 # define WIN_W 1800
 # define WIN_H 600
@@ -40,41 +40,41 @@
 ** Structures
 */
 
-struct					s_vec3
+struct s_vec3
 {
-	float				x;
-	float				y;
-	float				z;
+	float	x;
+	float	y;
+	float	z;
 };
 
 typedef struct s_vec3	t_vec3;
 
-struct					s_frame
+struct s_frame
 {
-	t_vec3				x;
-	t_vec3				y;
-	t_vec3				z;
-	t_vec3				o;
+	t_vec3	x;
+	t_vec3	y;
+	t_vec3	z;
+	t_vec3	o;
 };
 
 typedef struct s_frame	t_frame;
 
 typedef struct s_img
 {
-	void				*img;
-	char				*addr;
-	int					bits_per_pixel;
-	int					line_length;
-	int					endian;
-	int					width;
-	int					height;
-}						t_img;
+	void	*img;
+	char	*addr;
+	int		bits_per_pixel;
+	int		line_length;
+	int		endian;
+	int		width;
+	int		height;
+}	t_img;
 
 typedef struct s_sphere
 {
-	t_vec3				center;
-	float				radius;
-}						t_sphere;
+	t_vec3	center;
+	float	radius;
+}	t_sphere;
 
 /*
 ** Plane: represented by its normal (perpendicular vector) and offset
@@ -82,9 +82,9 @@ typedef struct s_sphere
 */
 typedef struct s_plane
 {
-	t_vec3				normal;
-	float				offset;
-}						t_plane;
+	t_vec3	normal;
+	float	offset;
+}	t_plane;
 
 /*
 ** Cylinder: the axis is the segment [a, b] and for each point on that
@@ -93,12 +93,12 @@ typedef struct s_plane
 */
 typedef struct s_cylinder
 {
-	t_vec3				a;
-	t_vec3				b;
-	float				radius;
-	float				height;
-	t_frame				fr;
-}						t_cylinder;
+	t_vec3	a;
+	t_vec3	b;
+	float	radius;
+	float	height;
+	t_frame	fr;
+}	t_cylinder;
 
 # define SPHERE 0
 # define PLANE 1
@@ -106,46 +106,45 @@ typedef struct s_cylinder
 
 typedef struct s_methods
 {
-	float				(*intersect)(void *shape, t_vec3 origin,
-						t_vec3 direction);
-	t_vec3				(*normal)(void *shape, t_vec3 point);
-	void				(*move)(void *shape, t_vec3 delta);
-	void				(*rotate)(void *obj, t_frame rot);
-}						t_methods;
+	float	(*intersect)(void *shape, t_vec3 origin, t_vec3 direction);
+	t_vec3	(*normal)(void *shape, t_vec3 point);
+	void	(*move)(void *shape, t_vec3 delta);
+	void	(*rotate)(void *obj, t_frame rot);
+}	t_methods;
 
 typedef struct s_shape
 {
-	void				*obj;
-	t_vec3				color;
-	t_methods			*methods;
-}						t_shape;
+	void		*obj;
+	t_vec3		color;
+	t_methods	*methods;
+}	t_shape;
 
-struct					s_vshape
+struct s_vshape
 {
-	t_shape				*arr;
-	int					size;
-	int					buf_size;
+	t_shape	*arr;
+	int		size;
+	int		buf_size;
 };
 
 typedef struct s_vshape	t_vshape;
 
-void					vshape_push_back(t_vshape *vec, t_shape elem);
-t_shape					vshape_pop_back(t_vshape *vec);
-void					vshape_assign(t_vshape *vec, int n, t_shape value);
-void					vshape_resize(t_vshape *vec, int n);
-t_vshape				*vshape_init(int n, t_shape value);
-t_vshape				*vshape_uninit(int n);
-void					vshape_free(t_vshape *vec);
-t_vshape				*vshape_copy(t_vshape *vec);
-void					vshape_map(t_vshape *vec, void (*f)(t_shape));
-void					vshape_map_sub(t_vshape *vec, t_shape (*f)(t_shape));
-t_shape					vshape_back(t_vshape *vec);
+void		vshape_push_back(t_vshape *vec, t_shape elem);
+t_shape		vshape_pop_back(t_vshape *vec);
+void		vshape_assign(t_vshape *vec, int n, t_shape value);
+void		vshape_resize(t_vshape *vec, int n);
+t_vshape	*vshape_init(int n, t_shape value);
+t_vshape	*vshape_uninit(int n);
+void		vshape_free(t_vshape *vec);
+t_vshape	*vshape_copy(t_vshape *vec);
+void		vshape_map(t_vshape *vec, void (*f)(t_shape));
+void		vshape_map_sub(t_vshape *vec, t_shape (*f)(t_shape));
+t_shape		vshape_back(t_vshape *vec);
 
 typedef struct s_light
 {
-	t_vec3				pos;
-	t_vec3				color;
-}						t_light;
+	t_vec3	pos;
+	t_vec3	color;
+}	t_light;
 
 /*
 ** Scene: contains the camera, the ambient color,
@@ -153,161 +152,151 @@ typedef struct s_light
 */
 typedef struct s_scene
 {
-	t_frame				camera;
-	float				fov;
-	t_vec3				ambient_color;
-	t_vshape			*objects;
-	t_vector			*lights;
-	t_methods			methods[4];
-}						t_scene;
+	t_frame		camera;
+	float		fov;
+	t_vec3		ambient_color;
+	t_vshape	*objects;
+	t_vector	*lights;
+	t_methods	methods[4];
+}	t_scene;
 
 typedef struct s_control
 {
-	int					shift;
-	int					path_tracing;
-	int					space;
-	int					reset;
-	t_vec3				delta;
+	int		shift;
+	int		path_tracing;
+	int		space;
+	int		reset;
+	t_vec3	delta;
 
-	int					selected_light;
-	int					active_light;
-}						t_control;
+	int		light_mode;
+	int		active_light;
+}	t_control;
 
 typedef struct s_ctx
 {
-	t_shape				*selected;
-	t_vec3				selection_color;
-	t_scene				*scene;
-	void				*mlx;
-	void				*mlx_win;
-	t_img				*img;
-	t_vec3				*img_vec;
-	int					rounds;
-	t_control			control;
-	int win_w; /* current width */
-	int win_h; /* current height */
-}						t_ctx;
+	t_shape		*selected;
+	t_vec3		selection_color;
+	t_scene		*scene;
+	void		*mlx;
+	void		*mlx_win;
+	t_img		*img;
+	t_vec3		*img_vec;
+	int			rounds;
+	t_control	control;
+	int			win_w; /* current width */
+	int			win_h; /* current height */
+}	t_ctx;
 
 typedef struct s_screen
 {
-	int					x;
-	int					y;
-	int					win_w;
-	int					win_h;
-}						t_screen;
+	int	x;
+	int	y;
+	int	win_w;
+	int	win_h;
+}	t_screen;
 
 /*
 ** Vector math
 */
-
-t_vec3					add(const t_vec3 a, const t_vec3 b);
-float					dot(const t_vec3 a, const t_vec3 b);
-t_vec3					cross(const t_vec3 a, const t_vec3 b);
-t_vec3					neg(const t_vec3 a);
-t_vec3					sub(const t_vec3 a, const t_vec3 b);
-t_vec3					scale(float f, const t_vec3 v);
-t_vec3					norm(t_vec3 v, float target_len);
-float					vec_length(t_vec3 v);
-t_vec3					pairwise_mul(t_vec3 a, t_vec3 b);
-t_vec3					pairwise_div(t_vec3 a, t_vec3 b);
-int						max(int a, int b);
+t_vec3		add(const t_vec3 a, const t_vec3 b);
+float		dot(const t_vec3 a, const t_vec3 b);
+t_vec3		cross(const t_vec3 a, const t_vec3 b);
+t_vec3		neg(const t_vec3 a);
+t_vec3		sub(const t_vec3 a, const t_vec3 b);
+t_vec3		scale(float f, const t_vec3 v);
+t_vec3		norm(t_vec3 v, float target_len);
+float		vec_length(t_vec3 v);
+t_vec3		pairwise_mul(t_vec3 a, t_vec3 b);
+t_vec3		pairwise_div(t_vec3 a, t_vec3 b);
+int			max(int a, int b);
 
 /*
 ** Coordinate transforms
 */
-t_vec3					to_frame(t_vec3 p, t_frame fr);
-t_vec3					to_world(t_vec3 p, t_frame fr);
-float					deg_to_rad(float degrees);
-t_frame					rotx(float degrees);
-t_frame					roty(float degrees);
-t_frame					rotz(float degrees);
-t_frame					f_to_world(t_frame f1, t_frame ref);
-t_frame					f_to_frame(t_frame f1, t_frame ref);
-t_vec3					v_to_frame(t_vec3 p, t_frame fr);
-t_vec3					v_to_world(t_vec3 p, t_frame fr);
-t_frame					z_collinear_to_vec(t_vec3 z, t_vec3 base);
-t_vec3					ray_at(float t, t_vec3 direction, t_vec3 origin);
+t_vec3		to_frame(t_vec3 p, t_frame fr);
+t_vec3		to_world(t_vec3 p, t_frame fr);
+float		deg_to_rad(float degrees);
+t_frame		rotx(float degrees);
+t_frame		roty(float degrees);
+t_frame		rotz(float degrees);
+t_frame		f_to_world(t_frame f1, t_frame ref);
+t_frame		f_to_frame(t_frame f1, t_frame ref);
+t_vec3		v_to_frame(t_vec3 p, t_frame fr);
+t_vec3		v_to_world(t_vec3 p, t_frame fr);
+t_frame		z_collinear_to_vec(t_vec3 z, t_vec3 base);
+t_vec3		ray_at(float t, t_vec3 direction, t_vec3 origin);
 
 /*
 ** Parsing and scene management
 */
-t_scene					*parse(char *filename);
-void					free_scene(t_scene *scene);
-t_ctx					init(char *filename);
+t_scene		*parse(char *filename);
+void		free_scene(t_scene *scene);
+t_ctx		init(char *filename);
 
 /*
 ** Drawing
 */
-void					pixel_put(t_img *img, int x, int y, t_vec3 color);
+void		pixel_put(t_img *img, int x, int y, t_vec3 color);
 
 /*
 ** Intersection and normals
 */
-float					intersect_sphere(t_sphere *s, t_vec3 origin,
-							t_vec3 direction);
-t_vec3					sphere_normal(t_sphere *s, t_vec3 point);
-float					intersect_plane(t_plane *pl, t_vec3 origin,
-							t_vec3 direction);
-t_vec3					plane_normal(t_plane *pl, t_vec3 point);
-float					intersect_cylinder(t_cylinder *cy, t_vec3 origin,
-							t_vec3 direction);
-t_vec3					cylinder_normal(t_cylinder *cy, t_vec3 point);
-t_vec3					norm_color(t_vec3 color);
+float		intersect_sphere(t_sphere *s, t_vec3 origin, t_vec3 direction);
+t_vec3		sphere_normal(t_sphere *s, t_vec3 point);
+float		intersect_plane(t_plane *pl, t_vec3 origin, t_vec3 direction);
+t_vec3		plane_normal(t_plane *pl, t_vec3 point);
+float		intersect_cylinder(t_cylinder *cy, t_vec3 origin, t_vec3 direction);
+t_vec3		cylinder_normal(t_cylinder *cy, t_vec3 point);
+t_vec3		norm_color(t_vec3 color);
 
 /*
 ** Ray tracing
 */
-void					trace(t_ctx *ctx);
-t_vec3					calc_direction(t_screen screen, float fov,
-							t_frame camera);
-t_shape					*intersect_scene(t_vec3 *p, t_vec3 direction,
-							t_scene *scene, t_vec3 o);
-int						is_shadow(t_vec3 o, t_vec3 d, t_scene *scene,
-							float len);
-t_vec3					shade_path(t_vec3 direction, t_vec3 o, t_scene *scene,
-							int depth);
-t_vec3					shade_ray(t_vec3 direction, t_vec3 o, t_scene *scene);
-void					update_show(t_ctx *ctx);
-void					pvec(t_vec3 v);
+void		trace(t_ctx *ctx);
+t_vec3		calc_direction(t_screen screen, float fov, t_frame camera);
+t_shape		*intersect_scene(t_vec3 *p, t_vec3 direction, t_scene *scene,
+				t_vec3 o);
+int			is_shadow(t_vec3 o, t_vec3 d, t_scene *scene, float len);
+t_vec3		shade_path(t_vec3 direction, t_vec3 o, t_scene *scene, int depth);
+t_vec3		shade_ray(t_vec3 direction, t_vec3 o, t_scene *scene);
+void		update_show(t_ctx *ctx);
+void		pvec(t_vec3 v);
 
 /*
 ** Event handling and utilities
 */
-int						loop(t_ctx *ctx);
-int						handle_key_up(int key, t_control *ctrl);
-int						handle_key_down(int key, t_ctx *ctx);
-int						handle_mouse(int k, int x, int y, t_ctx *ctx);
-t_img	*init_image(void *mlx, int win_w, int win_h); /* used in events.c */
-void	reset_show(t_ctx *ctx);                        /* used in events.c */
-void					virtual_resize(t_ctx *ctx, int new_w, int new_h);
-void					move_sphere(t_sphere *sp, t_vec3 delta);
-void					move_plane(t_plane *pl, t_vec3 delta);
-void					move_cylinder(t_cylinder *cy, t_vec3 delta);
+int			loop(t_ctx *ctx);
+int			handle_key_up(int key, t_control *ctrl);
+int			handle_key_down(int key, t_ctx *ctx);
+int			handle_mouse(int k, int x, int y, t_ctx *ctx);
+t_img		*init_image(void *mlx, int win_w, int win_h); /* used in events.c */
+void		reset_show(t_ctx *ctx); /* used in events.c */
+void		virtual_resize(t_ctx *ctx, int new_w, int new_h);
+void		move_sphere(t_sphere *sp, t_vec3 delta);
+void		move_plane(t_plane *pl, t_vec3 delta);
+void		move_cylinder(t_cylinder *cy, t_vec3 delta);
 
 /*
 ** Transformations
 */
 
-void					resize_sphere(t_sphere *sp, float delta_diameter);
-void					resize_cylinder_diameter(t_cylinder *cy,
-							float delta_diameter);
-void					resize_cylinder_height(t_cylinder *cy,
-							float delta_height);
+void		resize_sphere(t_sphere *sp, float delta_diameter);
+void		resize_cylinder_diameter(t_cylinder *cy, float delta_diameter);
+void		resize_cylinder_height(t_cylinder *cy, float delta_height);
 
 /*
 ** Rotations
 */
-void					rotate_plane(t_plane *pl, t_frame rot);
-void					rotate_cylinder(t_cylinder *cy, t_frame rot);
-void					rotate_camera(t_frame *cam, t_frame rot);
-void					rotate_sphere(t_sphere *sp, t_frame rot);
+void		rotate_plane(t_plane *pl, t_frame rot);
+void		rotate_cylinder(t_cylinder *cy, t_frame rot);
+void		rotate_camera(t_frame *cam, t_frame rot);
+void		rotate_sphere(t_sphere *sp, t_frame rot);
 
 /*
 ** Light transformations
 */
-void					translate_light(t_light *light, t_vec3 delta);
-void					rotate_light(t_light *light, t_frame rot);
-void					rotate_light_pivot(t_light *light, t_frame rot,
-							t_vec3 pivot);
+void		translate_light(t_light *light, t_vec3 delta);
+void		rotate_light(t_light *light, t_frame rot);
+void		rotate_light_pivot(t_light *light, t_frame rot, t_vec3 pivot);
 
 #endif

--- a/rt.h
+++ b/rt.h
@@ -6,7 +6,7 @@
 /*   By: amema <amema@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 14:35:28 by amema             #+#    #+#             */
-/*   Updated: 2025/03/09 21:06:23 by amema            ###   ########.fr       */
+/*   Updated: 2025/03/10 12:11:27 by amema            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -167,6 +167,9 @@ typedef struct s_control
 	int		space;
 	int		reset;
 	t_vec3	delta;
+
+	int		light_mode;
+	int		active_light;
 }	t_control;
 
 typedef struct s_ctx
@@ -290,5 +293,12 @@ void rotate_plane(t_plane *pl, t_frame rot);
 void rotate_cylinder(t_cylinder *cy, t_frame rot);
 void rotate_camera(t_frame *cam, t_frame rot);
 void rotate_sphere(t_sphere *sp, t_frame rot);
+
+/*
+** Light transformations
+*/
+void translate_light(t_light *light, t_vec3 delta);
+void rotate_light(t_light *light, t_frame rot);
+void rotate_light_pivot(t_light *light, t_frame rot, t_vec3 pivot);
 
 #endif

--- a/rt.h
+++ b/rt.h
@@ -3,25 +3,25 @@
 /*                                                        :::      ::::::::   */
 /*   rt.h                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: amema <amema@student.42.fr>                +#+  +:+       +#+        */
+/*   By: apuddu <apuddu@student.42roma.it>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 14:35:28 by amema             #+#    #+#             */
-/*   Updated: 2025/03/10 12:11:27 by amema            ###   ########.fr       */
+/*   Updated: 2025/03/10 17:21:13 by apuddu           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef RT_H
 # define RT_H
 
+# include <fcntl.h>
 # include <get_next_line.h>
 # include <libft.h>
-# include <vector.h>
 # include <math.h>
+# include <mlx.h>
 # include <stdio.h>
 # include <stdlib.h>
-# include <mlx.h>
-# include <fcntl.h>
 # include <unistd.h>
+# include <vector.h>
 
 # define WIN_W 1800
 # define WIN_H 600
@@ -40,41 +40,41 @@
 ** Structures
 */
 
-struct s_vec3
+struct					s_vec3
 {
-	float	x;
-	float	y;
-	float	z;
+	float				x;
+	float				y;
+	float				z;
 };
 
 typedef struct s_vec3	t_vec3;
 
-struct s_frame
+struct					s_frame
 {
-	t_vec3	x;
-	t_vec3	y;
-	t_vec3	z;
-	t_vec3	o;
+	t_vec3				x;
+	t_vec3				y;
+	t_vec3				z;
+	t_vec3				o;
 };
 
 typedef struct s_frame	t_frame;
 
 typedef struct s_img
 {
-	void	*img;
-	char	*addr;
-	int		bits_per_pixel;
-	int		line_length;
-	int		endian;
-	int		width;
-	int		height;
-}	t_img;
+	void				*img;
+	char				*addr;
+	int					bits_per_pixel;
+	int					line_length;
+	int					endian;
+	int					width;
+	int					height;
+}						t_img;
 
 typedef struct s_sphere
 {
-	t_vec3	center;
-	float	radius;
-}	t_sphere;
+	t_vec3				center;
+	float				radius;
+}						t_sphere;
 
 /*
 ** Plane: represented by its normal (perpendicular vector) and offset
@@ -82,9 +82,9 @@ typedef struct s_sphere
 */
 typedef struct s_plane
 {
-	t_vec3	normal;
-	float	offset;
-}	t_plane;
+	t_vec3				normal;
+	float				offset;
+}						t_plane;
 
 /*
 ** Cylinder: the axis is the segment [a, b] and for each point on that
@@ -93,12 +93,12 @@ typedef struct s_plane
 */
 typedef struct s_cylinder
 {
-	t_vec3	a;
-	t_vec3	b;
-	float	radius;
-	float	height;
-	t_frame	fr;
-}	t_cylinder;
+	t_vec3				a;
+	t_vec3				b;
+	float				radius;
+	float				height;
+	t_frame				fr;
+}						t_cylinder;
 
 # define SPHERE 0
 # define PLANE 1
@@ -106,45 +106,46 @@ typedef struct s_cylinder
 
 typedef struct s_methods
 {
-	float	(*intersect)(void *shape, t_vec3 origin, t_vec3 direction);
-	t_vec3	(*normal)(void *shape, t_vec3 point);
-	void	(*move)(void *shape, t_vec3 delta);
-	void	(*rotate)(void *obj, t_frame rot);
-}	t_methods;
+	float				(*intersect)(void *shape, t_vec3 origin,
+						t_vec3 direction);
+	t_vec3				(*normal)(void *shape, t_vec3 point);
+	void				(*move)(void *shape, t_vec3 delta);
+	void				(*rotate)(void *obj, t_frame rot);
+}						t_methods;
 
 typedef struct s_shape
 {
-	void		*obj;
-	t_vec3		color;
-	t_methods	*methods;
-}	t_shape;
+	void				*obj;
+	t_vec3				color;
+	t_methods			*methods;
+}						t_shape;
 
-struct s_vshape
+struct					s_vshape
 {
-	t_shape	*arr;
-	int		size;
-	int		buf_size;
+	t_shape				*arr;
+	int					size;
+	int					buf_size;
 };
 
 typedef struct s_vshape	t_vshape;
 
-void		vshape_push_back(t_vshape *vec, t_shape elem);
-t_shape		vshape_pop_back(t_vshape *vec);
-void		vshape_assign(t_vshape *vec, int n, t_shape value);
-void		vshape_resize(t_vshape *vec, int n);
-t_vshape	*vshape_init(int n, t_shape value);
-t_vshape	*vshape_uninit(int n);
-void		vshape_free(t_vshape *vec);
-t_vshape	*vshape_copy(t_vshape *vec);
-void		vshape_map(t_vshape *vec, void (*f)(t_shape));
-void		vshape_map_sub(t_vshape *vec, t_shape (*f)(t_shape));
-t_shape		vshape_back(t_vshape *vec);
+void					vshape_push_back(t_vshape *vec, t_shape elem);
+t_shape					vshape_pop_back(t_vshape *vec);
+void					vshape_assign(t_vshape *vec, int n, t_shape value);
+void					vshape_resize(t_vshape *vec, int n);
+t_vshape				*vshape_init(int n, t_shape value);
+t_vshape				*vshape_uninit(int n);
+void					vshape_free(t_vshape *vec);
+t_vshape				*vshape_copy(t_vshape *vec);
+void					vshape_map(t_vshape *vec, void (*f)(t_shape));
+void					vshape_map_sub(t_vshape *vec, t_shape (*f)(t_shape));
+t_shape					vshape_back(t_vshape *vec);
 
 typedef struct s_light
 {
-	t_vec3	pos;
-	t_vec3	color;
-}	t_light;
+	t_vec3				pos;
+	t_vec3				color;
+}						t_light;
 
 /*
 ** Scene: contains the camera, the ambient color,
@@ -152,153 +153,161 @@ typedef struct s_light
 */
 typedef struct s_scene
 {
-	t_frame		camera;
-	float		fov;
-	t_vec3		ambient_color;
-	t_vshape	*objects;
-	t_vector	*lights;
-	t_methods	methods[4];
-}	t_scene;
+	t_frame				camera;
+	float				fov;
+	t_vec3				ambient_color;
+	t_vshape			*objects;
+	t_vector			*lights;
+	t_methods			methods[4];
+}						t_scene;
 
 typedef struct s_control
 {
-	int		shift;
-	int		path_tracing;
-	int		space;
-	int		reset;
-	t_vec3	delta;
+	int					shift;
+	int					path_tracing;
+	int					space;
+	int					reset;
+	t_vec3				delta;
 
-	int		light_mode;
-	int		active_light;
-}	t_control;
+	int					selected_light;
+	int					active_light;
+}						t_control;
 
 typedef struct s_ctx
 {
-	t_shape		*selected;
-	t_vec3		selection_color;
-	t_scene		*scene;
-	void		*mlx;
-	void		*mlx_win;
-	t_img		*img;
-	t_vec3		*img_vec;
-	int			rounds;
-	t_control	control;
-	int			win_w; /* current width */
-	int			win_h; /* current height */
-}	t_ctx;
+	t_shape				*selected;
+	t_vec3				selection_color;
+	t_scene				*scene;
+	void				*mlx;
+	void				*mlx_win;
+	t_img				*img;
+	t_vec3				*img_vec;
+	int					rounds;
+	t_control			control;
+	int win_w; /* current width */
+	int win_h; /* current height */
+}						t_ctx;
 
 typedef struct s_screen
 {
-    int	x;
-    int	y;
-	int	win_w;
-	int	win_h;
-}	t_screen;
-
+	int					x;
+	int					y;
+	int					win_w;
+	int					win_h;
+}						t_screen;
 
 /*
 ** Vector math
 */
 
-t_vec3		add(const t_vec3 a, const t_vec3 b);
-float		dot(const t_vec3 a, const t_vec3 b);
-t_vec3		cross(const t_vec3 a, const t_vec3 b);
-t_vec3		neg(const t_vec3 a);
-t_vec3		sub(const t_vec3 a, const t_vec3 b);
-t_vec3		scale(float f, const t_vec3 v);
-t_vec3		norm(t_vec3 v, float target_len);
-float		vec_length(t_vec3 v);
-t_vec3		pairwise_mul(t_vec3 a, t_vec3 b);
-t_vec3		pairwise_div(t_vec3 a, t_vec3 b);
-int			max(int a, int b);
+t_vec3					add(const t_vec3 a, const t_vec3 b);
+float					dot(const t_vec3 a, const t_vec3 b);
+t_vec3					cross(const t_vec3 a, const t_vec3 b);
+t_vec3					neg(const t_vec3 a);
+t_vec3					sub(const t_vec3 a, const t_vec3 b);
+t_vec3					scale(float f, const t_vec3 v);
+t_vec3					norm(t_vec3 v, float target_len);
+float					vec_length(t_vec3 v);
+t_vec3					pairwise_mul(t_vec3 a, t_vec3 b);
+t_vec3					pairwise_div(t_vec3 a, t_vec3 b);
+int						max(int a, int b);
 
 /*
 ** Coordinate transforms
 */
-t_vec3		to_frame(t_vec3 p, t_frame fr);
-t_vec3		to_world(t_vec3 p, t_frame fr);
-float		deg_to_rad(float degrees);
-t_frame		rotx(float degrees);
-t_frame		roty(float degrees);
-t_frame		rotz(float degrees);
-t_frame		f_to_world(t_frame f1, t_frame ref);
-t_frame		f_to_frame(t_frame f1, t_frame ref);
-t_vec3		v_to_frame(t_vec3 p, t_frame fr);
-t_vec3		v_to_world(t_vec3 p, t_frame fr);
-t_frame		z_collinear_to_vec(t_vec3 z, t_vec3 base);
-t_vec3		ray_at(float t, t_vec3 direction, t_vec3 origin);
+t_vec3					to_frame(t_vec3 p, t_frame fr);
+t_vec3					to_world(t_vec3 p, t_frame fr);
+float					deg_to_rad(float degrees);
+t_frame					rotx(float degrees);
+t_frame					roty(float degrees);
+t_frame					rotz(float degrees);
+t_frame					f_to_world(t_frame f1, t_frame ref);
+t_frame					f_to_frame(t_frame f1, t_frame ref);
+t_vec3					v_to_frame(t_vec3 p, t_frame fr);
+t_vec3					v_to_world(t_vec3 p, t_frame fr);
+t_frame					z_collinear_to_vec(t_vec3 z, t_vec3 base);
+t_vec3					ray_at(float t, t_vec3 direction, t_vec3 origin);
 
 /*
 ** Parsing and scene management
 */
-t_scene		*parse(char *filename);
-void		free_scene(t_scene *scene);
-t_ctx		init(char *filename);
+t_scene					*parse(char *filename);
+void					free_scene(t_scene *scene);
+t_ctx					init(char *filename);
 
 /*
 ** Drawing
 */
-void		pixel_put(t_img *img, int x, int y, t_vec3 color);
+void					pixel_put(t_img *img, int x, int y, t_vec3 color);
 
 /*
 ** Intersection and normals
 */
-float		intersect_sphere(t_sphere *s, t_vec3 origin, t_vec3 direction);
-t_vec3		sphere_normal(t_sphere *s, t_vec3 point);
-float		intersect_plane(t_plane *pl, t_vec3 origin, t_vec3 direction);
-t_vec3		plane_normal(t_plane *pl, t_vec3 point);
-float		intersect_cylinder(t_cylinder *cy, t_vec3 origin, t_vec3 direction);
-t_vec3		cylinder_normal(t_cylinder *cy, t_vec3 point);
-t_vec3		norm_color(t_vec3 color);
+float					intersect_sphere(t_sphere *s, t_vec3 origin,
+							t_vec3 direction);
+t_vec3					sphere_normal(t_sphere *s, t_vec3 point);
+float					intersect_plane(t_plane *pl, t_vec3 origin,
+							t_vec3 direction);
+t_vec3					plane_normal(t_plane *pl, t_vec3 point);
+float					intersect_cylinder(t_cylinder *cy, t_vec3 origin,
+							t_vec3 direction);
+t_vec3					cylinder_normal(t_cylinder *cy, t_vec3 point);
+t_vec3					norm_color(t_vec3 color);
 
 /*
 ** Ray tracing
 */
-void		trace(t_ctx *ctx);
-t_vec3		calc_direction(t_screen screen, float fov, t_frame camera);
-t_shape		*intersect_scene(t_vec3 *p, t_vec3 direction, t_scene *scene,
-				t_vec3 o);
-int			is_shadow(t_vec3 o, t_vec3 d, t_scene *scene, float len);
-t_vec3		shade_path(t_vec3 direction, t_vec3 o, t_scene *scene, int depth);
-t_vec3		shade_ray(t_vec3 direction, t_vec3 o, t_scene *scene);
-void		update_show(t_ctx *ctx);
-void		pvec(t_vec3 v);
+void					trace(t_ctx *ctx);
+t_vec3					calc_direction(t_screen screen, float fov,
+							t_frame camera);
+t_shape					*intersect_scene(t_vec3 *p, t_vec3 direction,
+							t_scene *scene, t_vec3 o);
+int						is_shadow(t_vec3 o, t_vec3 d, t_scene *scene,
+							float len);
+t_vec3					shade_path(t_vec3 direction, t_vec3 o, t_scene *scene,
+							int depth);
+t_vec3					shade_ray(t_vec3 direction, t_vec3 o, t_scene *scene);
+void					update_show(t_ctx *ctx);
+void					pvec(t_vec3 v);
 
 /*
 ** Event handling and utilities
 */
-int			loop(t_ctx *ctx);
-int			handle_key_up(int key, t_control *ctrl);
-int			handle_key_down(int key, t_ctx *ctx);
-int			handle_mouse(int k, int x, int y, t_ctx *ctx);
-t_img		*init_image(void *mlx, int win_w, int win_h); /* used in events.c */
-void		reset_show(t_ctx *ctx); /* used in events.c */
-void		virtual_resize(t_ctx *ctx, int new_w, int new_h);
-void		move_sphere(t_sphere *sp, t_vec3 delta);
-void		move_plane(t_plane *pl, t_vec3 delta);
-void		move_cylinder(t_cylinder *cy, t_vec3 delta);
+int						loop(t_ctx *ctx);
+int						handle_key_up(int key, t_control *ctrl);
+int						handle_key_down(int key, t_ctx *ctx);
+int						handle_mouse(int k, int x, int y, t_ctx *ctx);
+t_img	*init_image(void *mlx, int win_w, int win_h); /* used in events.c */
+void	reset_show(t_ctx *ctx);                        /* used in events.c */
+void					virtual_resize(t_ctx *ctx, int new_w, int new_h);
+void					move_sphere(t_sphere *sp, t_vec3 delta);
+void					move_plane(t_plane *pl, t_vec3 delta);
+void					move_cylinder(t_cylinder *cy, t_vec3 delta);
 
 /*
 ** Transformations
 */
 
-void resize_sphere(t_sphere *sp, float delta_diameter);
-void resize_cylinder_diameter(t_cylinder *cy, float delta_diameter);
-void resize_cylinder_height(t_cylinder *cy, float delta_height);
+void					resize_sphere(t_sphere *sp, float delta_diameter);
+void					resize_cylinder_diameter(t_cylinder *cy,
+							float delta_diameter);
+void					resize_cylinder_height(t_cylinder *cy,
+							float delta_height);
 
 /*
 ** Rotations
 */
-void rotate_plane(t_plane *pl, t_frame rot);
-void rotate_cylinder(t_cylinder *cy, t_frame rot);
-void rotate_camera(t_frame *cam, t_frame rot);
-void rotate_sphere(t_sphere *sp, t_frame rot);
+void					rotate_plane(t_plane *pl, t_frame rot);
+void					rotate_cylinder(t_cylinder *cy, t_frame rot);
+void					rotate_camera(t_frame *cam, t_frame rot);
+void					rotate_sphere(t_sphere *sp, t_frame rot);
 
 /*
 ** Light transformations
 */
-void translate_light(t_light *light, t_vec3 delta);
-void rotate_light(t_light *light, t_frame rot);
-void rotate_light_pivot(t_light *light, t_frame rot, t_vec3 pivot);
+void					translate_light(t_light *light, t_vec3 delta);
+void					rotate_light(t_light *light, t_frame rot);
+void					rotate_light_pivot(t_light *light, t_frame rot,
+							t_vec3 pivot);
 
 #endif


### PR DESCRIPTION
features/changes: 
add: `light_transform.c`

- **Light Translation:**
  - **Key Bindings:**  
    - **W, A, S, D** for horizontal movement  
    - **SPACE** for vertical translation
  - **Implementation:**  
    - In `controller.c`, when light mode is active, the key events map to specific translation vectors (e.g., `'w'` → (0, 0, 0.3), `'d'` → (0.3, 0, 0), etc.).
    - The `translate_light` function in `light_transform.c` applies these deltas by adding them to the light's current position.

- **Light Rotation:**
  - **Key Bindings:**  
    - **I / K:** Rotate around the X-axis (5° per press, positive for 'i', negative for 'k')  
    - **J / L:** Rotate around the Y-axis (5° per press, positive for 'j', negative for 'l')  
    - **U / O:** Rotate around the Z-axis (5° per press, positive for 'u', negative for 'o')
  - **Implementation:**  
    - The input handler in `controller.c` checks for these keys when light mode is enabled.
    - Depending on the key pressed, it constructs a rotation frame using `rotx`, `roty`, or `rotz` functions with a 5° + increment.
    - The rotation frame is then passed to the `rotate_light` function in `light_transform.c`, which transforms the light's position to reflect the rotation.

- **Light Rotation Pivot:**
  - **Implementation:**  
    - The function `rotate_light_pivot` (located in `light_transform.c`) allows rotating a light around an arbitrary pivot point.
    - It calculates the relative vector from the pivot to the light, applies the rotation, and then recalculates the light’s absolute position by adding the pivot back.